### PR TITLE
modif sur bouton accueil et liens des questions

### DIFF
--- a/quizzpage.css
+++ b/quizzpage.css
@@ -54,6 +54,10 @@ main {
 
 }
 
+.bi-house-door-fill:hover {
+    transform: scale(1.2);
+}
+
 .navbar svg {
     fill: var(--beige);
 }
@@ -118,6 +122,7 @@ main {
     align-content: center;
     align-items: center;
     border: none;
+    text-decoration: none;
 }
 
 .reponse:hover {

--- a/quizzpage.html
+++ b/quizzpage.html
@@ -11,7 +11,7 @@
 <body>
     <header>
         <nav class="navbar">
-            <a href=""><svg xmlns="http://www.w3.org/2000/svg" fill="#000" class="bi-house-door-fill"
+            <a href="accueil.html"><svg xmlns="http://www.w3.org/2000/svg" fill="#000" class="bi-house-door-fill"
                     viewBox="0 0 16 16">
                     <path
                         d="M6.5 14.5v-3.505c0-.245.25-.495.5-.495h2c.25 0 .5.25.5.5v3.5a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.146-.354L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293L8.354 1.146a.5.5 0 0 0-.708 0l-6 6A.5.5 0 0 0 1.5 7.5v7a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5" />

--- a/quizzpageimg.css
+++ b/quizzpageimg.css
@@ -54,6 +54,10 @@ main {
 
 }
 
+.bi-house-door-fill:hover {
+    transform: scale(1.2);
+}
+
 .navbar svg {
     fill: var(--beige);
 }
@@ -85,7 +89,6 @@ main {
     box-shadow: 0.2rem 0.2rem 0.2rem rgba(0, 0, 0, 0.2);
     font-weight: bold;
     display: flex;
-
 }
 
 /* #endregion */
@@ -121,6 +124,10 @@ main {
     align-content: space-between;
     padding: 0.75rem;
     border-radius: 0.75rem;
+}
+
+a {
+    text-decoration: none;
 }
 
 .reponse {

--- a/quizzpageimg.html
+++ b/quizzpageimg.html
@@ -11,7 +11,7 @@
 <body>
     <header>
         <nav class="navbar">
-            <a href=""><svg xmlns="http://www.w3.org/2000/svg" fill="#000" class="bi-house-door-fill"
+            <a href="accueil.html"><svg xmlns="http://www.w3.org/2000/svg" fill="#000" class="bi-house-door-fill"
                     viewBox="0 0 16 16">
                     <path
                         d="M6.5 14.5v-3.505c0-.245.25-.495.5-.495h2c.25 0 .5.25.5.5v3.5a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.146-.354L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293L8.354 1.146a.5.5 0 0 0-.708 0l-6 6A.5.5 0 0 0 1.5 7.5v7a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5" />
@@ -35,19 +35,30 @@
                 <img src="imagetestpagequizz.jpg" alt="Photo panoramique de Paris">
             </div>
             <section class="blocReponse">
-                <button class="reponse">
-                    <a href="end.html">Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatibus ddd</a>
+                <a href="end.html">
+                    <button class="reponse">
+                        Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatibus ddd
+                    </button>
+                </a>
 
-                </button>
-                <button class="reponse">
-                    <a href="end.html">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Enim officiis</a>
-                </button>
-                <button class="reponse">
-                    <a href="end.html">Lorem ipsum dolor sit amet consectetur adipisicing elit. Illum</a>
-                </button>
-                <button class="reponse">
-                    <a href="end.html">Lorem ipsum dolor, sit amet consectetur adipisicing elit. Repudiandae</a>
-                </button>
+                <a href="end.html">
+                    <button class="reponse">
+                        Lorem ipsum, dolor sit amet consectetur adipisicing elit. Enim officiis
+                    </button>
+                </a>
+
+                <a href="end.html">
+                    <button class="reponse">
+                        Lorem ipsum dolor sit amet consectetur adipisicing elit. Illum
+                    </button>
+                </a>
+
+                <a href="end.html">
+                    <button class="reponse">
+                        Lorem ipsum dolor, sit amet consectetur adipisicing elit. Repudiandae
+                    </button>
+                </a>
+
         </div>
         </section>
 


### PR DESCRIPTION
Sur la page "quizz sans image"
- bouton accueil (maison) cliquable
- hover ajouté sur l'accueil (maison)
- retiré le soulignage sous les liens

Sur la page "quizz avec image"
- bouton accueil (maison) cliquable
- hover ajouté sur l'accueil (maison)
- retiré le soulignage sous les liens
- déplacé le bouton dans le lien pour que toute la réponse soit cliquable